### PR TITLE
fix: replace instructions with correct stores

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,8 @@
-numa_stress:
-	g++ -std=c++20 -O2 -mavx512f -pthread numa_stress.cc -lnuma -o numa_stress
+CXXFLAGS = -std=c++20 -O2 -mavx512f -pthread -lnuma
+LDFLAGS = -pthread -lnuma
+
+numa_stress: numa_stress.cc
+
+.PHONY: clean
+clean:
+	rm -f numa_stress


### PR DESCRIPTION
- previously the instruction used in the raw assembly were wrong, they were load instructions, not the non-temporal stores I wanted to use to load up the cache line really fast
- add a better total speed calculation based on all the megs that ran through and the time elapsed since thread creation, this may yield poorer precision but it's better than summing up the per second estimated values inside the worker threads
- replace the remote numa memory allocation with a function that doesn't fail, the posix_memalign + move pages to remote node way doesn't work for me